### PR TITLE
Checking that received message is a report (not heartbeat)

### DIFF
--- a/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/handler/XiaomiItemHandler.java
+++ b/addons/binding/org.openhab.binding.mihome/src/main/java/org/openhab/binding/mihome/handler/XiaomiItemHandler.java
@@ -198,10 +198,12 @@ public class XiaomiItemHandler extends BaseThingHandler implements XiaomiItemUpd
                     }
                     break;
                 case "motion":
-                    boolean hasMotion = data.has("status") && data.get("status").getAsString().equals("motion");
-                    updateState(CHANNEL_MOTION, hasMotion ? OnOffType.ON : OnOffType.OFF);
-                    if (hasMotion) {
-                        updateState(CHANNEL_LAST_MOTION, new DateTimeType());
+                    if (message.get("cmd").getAsString().equals("report")) {
+                        boolean hasMotion = data.has("status") && data.get("status").getAsString().equals("motion");
+                        updateState(CHANNEL_MOTION, hasMotion ? OnOffType.ON : OnOffType.OFF);
+                        if (hasMotion) {
+                            updateState(CHANNEL_LAST_MOTION, new DateTimeType());
+                        }
                     }
                     break;
                 case "switch":


### PR DESCRIPTION
Have solved my problem with false triggered motion when openhab received from gateway incorrectly formated message:
INFO: {"cmd":"heartbeat","model":"motion","sid":"158d000116c486","short_id":41334,"data":"{"status":"motion"}"}